### PR TITLE
When navigating on the file pane via '..' one up, it failed on root p…

### DIFF
--- a/src/treectl.c
+++ b/src/treectl.c
@@ -1470,7 +1470,8 @@ FindItemFromPath(
 
          } while (*lpszPath);
 
-         bReturn = MatchNode(hwndLB, szElement, &dwIndex, &iPreviousNode, &pPreviousNode);
+         if (*szElement)
+            bReturn = MatchNode(hwndLB, szElement, &dwIndex, &iPreviousNode, &pPreviousNode);
       }
       else {
          // e.g. drive change, when root node is different than lpszPath


### PR DESCRIPTION
When navigating on the file pane via '..' one up, it failed on root plus one.
E.g. Going back up from c:\bla via .. didn't result in showing c:\ on the left pane, but c:\bla
This only affects the UNC capable version